### PR TITLE
add FDMNES output to webapp, some i/o tweaks

### DIFF
--- a/larixite/fdmnes.py
+++ b/larixite/fdmnes.py
@@ -369,9 +369,14 @@ def struct2fdmnes(inp: Union[str, Path], absorber:
     if filename is None:
         filename = f'unknown.{format}'
 
+    if isinstance(absorber, str):
+        absorber = Element(absorber)
+    elif isinstance(absorber, int):
+        absorber = Element.from_Z(absorber)
+
     structs = get_structure_from_text(inp, absorber, frame=frame, format=format,
                                       filename=filename)
-
+    fout_name = f"{filename.replace('.', '_')}_{absorber.symbol}.inp"
     fdm = FdmnesXasInput(structs, absorber=absorber)
-    return {'fdmfile.txt': '1\njob_inp.txt\n',
-           'job_inp.txt': fdm.get_input()}
+    return {'fdmfile.txt': f'1\n{fout_name}\n',
+            fout_name: fdm.get_input()}

--- a/larixite/utils.py
+++ b/larixite/utils.py
@@ -5,8 +5,13 @@ Various utilities for Larixite
 
 import os
 import logging
+import io
+from typing import Union
+from gzip import GzipFile
 from pathlib import Path
 from packaging import version as pkg_version
+from charset_normalizer import from_bytes
+
 from pyshortcuts import get_homedir, bytes2str, isotime
 
 HAS_IPYTHON = False
@@ -134,3 +139,58 @@ def show_loggers(clear_handlers=False):
         for handler in logger.handlers:
             print(f"+-> Handler: {handler}")
             print(f"+-> Level: {handler.level} ({logging.getLevelName(handler.level)})")
+
+
+
+
+def bytes2str(bytedata):
+    "decode bytes using charset_normalizer.from_bytes"
+    return str(from_bytes(bytedata).best())
+
+def get_path(val: Union[Path, str, bytes]):
+    """return best guess for a posix-style path name from an input string
+    """
+    if isinstance(val, bytes):
+        val = bytes2str(val)
+    if isinstance(val, str):
+        val = Path(val)
+    return val.absolute()
+
+def is_gzip(filename):
+    "is a file gzipped?"
+    with open(get_path(filename), 'rb') as fh:
+        return fh.read(3) == b'\x1f\x8b\x08'
+    return False
+
+def read_textfile(filename: Union[Path, io.IOBase, str, bytes], size=None) -> str:
+    """read text from a file as string (decoding from bytes)
+
+    Argument
+    --------
+    filename  (Path, str, bytes, or open File): file or file-like object to read
+    size  (int or None): number of bytes to read
+
+    Returns
+    -------
+    text of file as string.
+
+    Notes
+    ------
+    1. the file encoding is detected with charset_normalizer.from_bytes
+       which is then used to decode bytes read from file.
+    2. line endings are normalized to be '\n', so that
+       splitting on '\n' will give a list of lines.
+    3. if filename is given, it can be a gzip-compressed file
+    """
+    text = ''
+
+
+    if isinstance(filename, io.IOBase):
+        text = filename.read(size)
+        if filename.mode == 'rb':
+            text = bytes2str(text)
+    else:
+        fopen = GzipFile if is_gzip(filename) else open
+        with fopen(get_path(filename), 'rb') as fh:
+            text = bytes2str(fh.read(size))
+    return text.replace('\r\n', '\n').replace('\r', '\n')

--- a/larixite/webapp/templates/index.html
+++ b/larixite/webapp/templates/index.html
@@ -125,27 +125,40 @@
 
      </td>
      <td>
-         {% if cif_link or feff_links:  %}
+         {% if cif_link or zip_link or out_links:  %}
        <div class=subtitle> Download Results </div>
        <table padding=3 >
          <tr><td> File Link</td> <td> Crystal Site/File Type</td></tr>
+         {% if zip_link: %}
+           <tr class='even' >
+             <td><a href="{{url_for('zipfile', cifid=zip_link[1],
+             absorber=zip_link[2],  edge=zip_link[3],
+             cluster_size=zip_link[4], with_h=zip_link[5],
+             form=zip_link[6], fname=zip_link[0]) }}"> {{  zip_link[0] }} </a></td>
+             <td> &nbsp;  Zip File, all outputs </td>
+           </tr>
+         {% endif %}
          {% if cif_link: %}
+           <tr class='odd'>
              <td><a href="{{url_for('ciffile', cifid=cif_link[1], fname=cif_link[0]) }}"> {{
                  cif_link[0] }} </a></td>
              <td> &nbsp;  CIF File </td>
-           </tr>
-           {% endif %}
+          </tr>
+         {% endif %}
 
-         {% if feff_links: %}
-         {% for link, data in feff_links.items() %}
+         {% if out_links: %}
+         {% for link, data in out_links.items() %}
            <tr class={{ loop.cycle('even', 'odd') }}>
-             <td><a href="{{url_for('feffinp', cifid=data[1],
+             <td><a href="{{url_for('output', cifid=data[1],
              absorber=data[2],  edge=data[3], site=data[4],
-             cluster_size=data[5], with_h=data[6], fname=link )}}">{{ link }}</a></td>
+             cluster_size=data[5], with_h=data[6], form=data[7],
+             fname=link )}}">{{ link }}</a></td>
              <td> &nbsp;  {{ data[0] }} </td>
            </tr>
-           {% endfor %}
-           {% endif %}
+         {% endfor %}
+         {% endif %}
+
+
        </table>
            {% endif %}
      </td>

--- a/larixite/webapp/templates/index.html
+++ b/larixite/webapp/templates/index.html
@@ -113,11 +113,7 @@
           <input type="submit" name="feff" value="Generate Feff Inputs">
         </td>
         <td colspan=2>
-          GENERATE FDMNES Coming Soon
-          <!--
           <input type="submit" name="fdmnes" value="Generate FDMNES Input">
-
-          -->
         </td>
       </tr>
     </table>

--- a/larixite/webapp/webapp.py
+++ b/larixite/webapp/webapp.py
@@ -3,6 +3,10 @@ import os
 import time
 import numpy as np
 from pathlib import Path
+from zipfile import ZipFile
+import tempfile
+import random
+from string import ascii_lowercase
 
 from flask import (Flask, redirect, url_for, render_template, flash,
                    request, session, Response, send_from_directory)
@@ -10,6 +14,7 @@ from werkzeug.utils import secure_filename
 
 from larixite import get_amcsd, cif_cluster, cif2feffinp, read_cif_structure
 from larixite.utils import get_homedir
+from larixite.fdmnes import struct2fdmnes
 
 from xraydb import atomic_number
 from xraydb.chemparser import chemparse
@@ -31,6 +36,13 @@ app.secret_key = 'persuasive butternut lanterns'
 app.config.from_object(__name__)
 
 cifdb = config = None
+
+
+def random_string(n=12):
+    """  random_string(n)
+    generates a random string of length n [a-z](n)
+    """
+    return ''.join([random.choice(ascii_lowercase) for i in range(n)])
 
 def connect(session, clear=False, cifid=None):
     global cifdb, config
@@ -109,7 +121,7 @@ def cifs(cifid=None):
         cluster = cif_cluster(config['ciftext'])
         config['atoms'] = []
         config['cif_link'] = None
-        config['feff_links'] = {}
+        config['outlinks'] = {}
         config['all_sites'] = cluster.all_sites
 
         for at in chemparse(cluster.formula.replace(' ', '')):
@@ -159,7 +171,8 @@ def cifs(cifid=None):
             config['ciffile']  = ''
             config['atoms'] = []
             config['cif_link'] = None
-            config['feff_links'] = {}
+            config['zip_link'] = None
+            config['out_links'] = {}
 
 
         elif 'feff' in request.form.keys():
@@ -178,11 +191,37 @@ def cifs(cifid=None):
                 elif config['cifid'] is not None:
                     cifid = config['cifid']
                     config['cif_link'] = (f'AMSCD_{cifid}.cif', cifid)
-                config['feff_links'] = {}
+                    config['zip_link'] = (f'AMSCD_{cifid}_feff.zip', cifid,
+                                         absorber, edge, cluster_size, with_h, 'feff')
+                config['out_links'] = {}
                 for slabel, sindex in config['all_sites'][absorber].items():
                     link = f'feff_{cifid}_{absorber}{sindex}_{edge}.inp'
-                    config['feff_links'][link] = (slabel, cifid, absorber, edge, sindex,
-                                                  cluster_size, with_h)
+                    config['out_links'][link] = (slabel, cifid, absorber, edge, sindex,
+                                                  cluster_size, with_h, 'feff')
+
+
+        elif 'fdmnes' in request.form.keys():
+            config['absorber'] = absorber = request.form.get('absorbing_atom')
+            config['edge'] = edge =request.form.get('edge')
+            config['cluster_size'] = cluster_size = request.form.get('cluster_size')
+            with_h = request.form.get('with_h') in ('1', 'on', 'True', 1, True)
+            config['with_h'] = with_h = int(with_h)
+            if config['ciftext'] is not None:
+                out = struct2fdmnes(config['ciftext'], absorber=absorber,
+                                        filename=f'AMSCD_{cifid}.cif')
+                cifid = config['cifid']
+                if config['ciffile'] not in ('', None, 'None'):
+                    cifid = config['ciffile']
+                elif config['cifid'] is not None:
+                    cifid = config['cifid']
+                    config['cif_link'] = (f'AMSCD_{cifid}.cif', cifid)
+                    config['zip_link'] = (f'AMSCD_{cifid}_fdmnes.zip', cifid,
+                                         absorber, edge, cluster_size, with_h, 'fdmnes')
+                config['out_links'] = {}
+                for slabel, text in out.items():
+                    link = f'fdmnes_{slabel}'
+                    config['out_links'][slabel] = (slabel, cifid, absorber, edge, 0,
+                                                   cluster_size, with_h, 'fdmnes')
 
     return render_template('index.html', **config)
 
@@ -194,11 +233,7 @@ def index():
     return render_template('index.html', **config)
 
 
-@app.route('/feffinp/<cifid>/<absorber>/<site>/<edge>/<cluster_size>/<with_h>/<fname>')
-def feffinp(cifid=None, absorber=None, site=1, edge='K', cluster_size=7.0,
-            with_h=False, fname=None):
-    connect(session, cifid=cifid)
-    global cifdb, config
+def get_elements(absorber):
     if absorber.startswith('Wat'):
         absorber.replace('Wat', 'O')
     if absorber.startswith('O-H'):
@@ -216,25 +251,77 @@ def feffinp(cifid=None, absorber=None, site=1, edge='K', cluster_size=7.0,
                 stoich = chemparse(absorber[:].replace('M', ''))
             except:
                 stoich = {}
+    return stoich, absorber
 
+
+@app.route('/zipfile/<cifid>/<absorber>/<edge>/<cluster_size>/<with_h>/<form>/<fname>')
+def zipfile(cifid=None, absorber=None, edge='K', cluster_size=7.0,
+            with_h=False, form='feff', fname=None):
+    connect(session, cifid=cifid)
+    global cifdb, config
+    stoich, absorber = get_elements(absorber)
     if len(stoich) != 1:
-        txt = f"could not parse absorber: '{absorber}' for CIF {cifid}  {stoich}"
+        flash(f"could not parse absorber: '{absorber}' for CIF {cifid}  {stoich}")
+        return
+    absorber = list(stoich.keys())[0]
+    if with_h in  ('1', 'on', 'True', 1, True):
+        with_h = 1
     else:
-        try:
-            xcifid = int(cifid)
-        except:
-            xcifid = None
+        with_h = 0
+    cluster = cif_cluster(config['ciftext'], absorber=absorber)
+    config['all_sites'] = cluster.all_sites
 
-        absorber = list(stoich.keys())[0]
-        if with_h in  ('1', 'on', 'True', 1, True):
-            with_h = 1
-        else:
-            with_h = 0
-        feffinp = cif2feffinp(config['ciftext'], absorber, edge=edge,
+    tfolder = Path(tempfile.gettempdir())
+    tfile = random_string() + '.zip'
+    zfile = ZipFile(Path(tfolder, tfile), mode='w')
+    zfile.writestr(f'AMSCD_{cifid}.cif', config['ciftext'])
+    if form =='feff':
+        for slabel, sindex in config['all_sites'][absorber].items():
+            oname = f'feff_{cifid}_{absorber}{sindex}_{edge}.inp'
+            result = cif2feffinp(config['ciftext'], absorber, edge=edge,
+                                    cluster_size=float(cluster_size), cifid=int(cifid),
+                                 with_h=with_h, absorber_site=int(sindex))
+            zfile.writestr(oname, result)
+    elif form == 'fdmnes':
+        out = struct2fdmnes(config['ciftext'], absorber=absorber,
+                                filename=f'AMSCD_{cifid}.cif')
+        for key, val in out.items():
+            zfile.writestr(key, val)
+    zfile.close()
+
+    return send_from_directory(tfolder, tfile, mimetype='application/zip',
+                              as_attachment=True,  download_name=fname)
+
+@app.route('/output/<cifid>/<absorber>/<site>/<edge>/<cluster_size>/<with_h>/<form>/<fname>')
+def output(cifid=None, absorber=None, site=1, edge='K', cluster_size=7.0,
+            with_h=False, form='feff', fname=None):
+    connect(session, cifid=cifid)
+    global cifdb, config
+    stoich, absorber = get_elements(absorber)
+    if len(stoich) != 1:
+        flash(f"could not parse absorber: '{absorber}' for CIF {cifid}  {stoich}")
+        return
+
+    try:
+        xcifid = int(cifid)
+    except:
+        xcifid = None
+
+    absorber = list(stoich.keys())[0]
+    if with_h in  ('1', 'on', 'True', 1, True):
+        with_h = 1
+    else:
+        with_h = 0
+    if form =='feff':
+        result = cif2feffinp(config['ciftext'], absorber, edge=edge,
                     cluster_size=float(cluster_size), cifid=xcifid,
                     with_h=with_h, absorber_site=int(site))
+    elif form == 'fdmnes':
+        out = struct2fdmnes(config['ciftext'], absorber=absorber,
+                            filename=f'AMSCD_{xcifid}.cif')
+        result = out[fname]
 
-    return Response(feffinp, mimetype='text/plain')
+    return Response(result, mimetype='text/plain')
 
 
 @app.route('/ciffile/<cifid>/<fname>')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,12 @@ dependencies = [
     "pyshortcuts",
 ]
 
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 keywords = ["X-ray spectroscopy", "Crystallography"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
This adds FDMNES outputs to the larixite web/Flask app.
It also adds a Zip file to download all outputs, including the CIF file.

This also adds a couple of convenience functions for `struct` and `fdmnes` to allow generating structure results not from a filename/Path, but from the *text* of a CIF file, and not writing files but returning the *text* of the output files.  That is,  without doing I/O in the calculation function (Separating calculation from I/O is sort of like the MVC discussions -- generally a good idea, sometimes hard to always follow in practice).   

Unfortunately, pymatgen's XYZ function *needs* a real file or Path, and cannot use a `StringIO(text)` buffer.  If that gets resolved, then  `get_structure` could call `get_structure_from_text`, but at the moment that is sort of clunky, so I ended up not doing that, and leaving sort of duplicate code that should be cleaned up (like, when `pymatgen.io.xys.XYZ` can read from StringIO).

Anyway, this branch works for me for local generation of FDMNES files and Zip Files of all outputs.
