### PR TITLE
Minor fixes for 2025.5.1

### DIFF
--- a/larixite/fdmnes.py
+++ b/larixite/fdmnes.py
@@ -61,8 +61,10 @@ class FdmnesXasInput:
     struct_type: Union[str, None] = None  #: type of the structure
     vmax: Union[float, None] = None  #: maximum potential value for molecules
     erange: str = "-20.0 0.1 70.0 1.0 100.0"  #: energy range
+    fileout_prefix: str = "job"  #: prefix of the output filename for the FDMNES job (extension: .inp)
     tmplpath: Union[str, Path, None] = None  #: path to the FDMNES input template
-    params: Union[dict, None] = None  #: parameters for FDMNES
+    params: Union[dict[str, bool], None] = None  #: enable/disable parameters for FDMNES
+    spacer : str = "   "  #: spacer for the FDMNES input text
 
     def __post_init__(self):
         """Validate and optimize attributes"""
@@ -214,7 +216,7 @@ class FdmnesXasInput:
         if "crys" in struct_type.lower():
             #: absorber
             structout.append("Z_absorber")
-            structout.append(f"   {self.absorber.Z}")
+            structout.append(f"{self.spacer}{self.absorber.Z}")
             #: space group
             spgrp = self.xs.space_group
             if spgrp == 1:  #: FDMNES doesn't recognize 1 as a space group -> `P1`
@@ -222,14 +224,14 @@ class FdmnesXasInput:
             if spgrp == 2:  #: FDMNES doesn't recognize 2 as a space group -> `P-1`
                 spgrp = "P-1"
             structout.append("Spgroup")
-            structout.append(f"   {spgrp}")
+            structout.append(f"{self.spacer}{spgrp}")
             #: occupancy
             structout.append("Occupancy")
             #: crystal
             structout.append("Crystal")
             lattice = self.xs.sym_struct.lattice
             structout.append(
-                f"   {lattice.a} {lattice.b} {lattice.c} {lattice.alpha} {lattice.beta} {lattice.gamma}"
+                f"{self.spacer}{lattice.a} {lattice.b} {lattice.c} {lattice.alpha} {lattice.beta} {lattice.gamma}"
             )
             for (
                 idx,
@@ -262,14 +264,14 @@ class FdmnesXasInput:
             structout.append("   1")
             #: molecule
             structout.append("Molecule")
-            structout.append("   1.0 1.0 1.0 90.0 90.0 90.0")
+            structout.append(f"{self.spacer}1.0 1.0 1.0 90.0 90.0 90.0")
             for i, dist in sorted(map_mol_by_dist, key=lambda x: x[1]):
                 site = mol[i]
                 if not len(site.species) == 1:
                     raise NotImplementedError("TODO: partial site occupancy")
                 el = site.species.elements[0]
                 structout.append(
-                    f"  {el.Z:>3d} {site.x:15.10f} {site.y:15.10f} {site.z:15.10f} ! {site.label:>6s} {dist:10.5f} "
+                    f"{el.Z:>3d} {site.x:15.10f} {site.y:15.10f} {site.z:15.10f} ! {site.label:>6s} {dist:10.5f}"
                 )
         else:
             errmsg = f"Structure type `{struct_type}` not supported"
@@ -281,17 +283,18 @@ class FdmnesXasInput:
         """Get the vmax section of the input"""
         if self.vmax is not None:
             vmax = ["Vmax"]
-            vmax.append("   -6")
+            vmax.append(f"{self.spacer}-6")
             return "\n".join(vmax)
         else:
             return "! Vmax"
 
     def get_input(self, comment: str = "", struct_type: str = None) -> str:
+        """Get the FDMNES input text"""
         params = self.params.copy()
         template = open(self.tmplpath, "r").read()
 
         comment = (
-            f"   {self.xs.name}: {self.absorber.symbol} ({self.absorber.Z}) {self.edge} edge"
+            f"{self.spacer}{self.xs.name}: {self.absorber.symbol} ({self.absorber.Z}) {self.edge} edge"
             + comment
         )
         #: fill the template
@@ -303,9 +306,10 @@ class FdmnesXasInput:
             "version": vers,
             "pymatgen_version": pymatgen_version,
             "comment": comment,
-            "edge": self.edge,
-            "radius": f"{self.radius:.2f}",
-            "erange": self.erange,
+            "filout": self.spacer + self.fileout_prefix,
+            "edge": f"{self.spacer}{self.edge}",
+            "radius": f"{self.spacer}{self.radius:.2f}",
+            "erange": self.spacer + self.erange,
             "vmax": self.get_vmax(),
             "struct_type": self.struct_type,
             "structure": self.get_structure(struct_type=struct_type),
@@ -316,9 +320,8 @@ class FdmnesXasInput:
         return strict_ascii(template.format(**conf))
 
     def write_input(
-        self, inputtext: Union[str, None] = None, outdir: Union[str, Path, None] = None
-    ) -> None:
-        """Write the FDMNES input text to disk (as `job_inp.txt`) and return the output directory"""
+        self, inputtext: Union[str, None] = None, outdir: Union[str, Path, None] = None) -> Path:
+        """Write the FDMNES input text to disk and return the output directory"""
         if inputtext is None:
             inputtext = self.get_input()
         if outdir is None:
@@ -332,11 +335,12 @@ class FdmnesXasInput:
         if isinstance(outdir, str):
             outdir = Path(outdir)
         outdir.mkdir(parents=True, exist_ok=True)
-        fnout = outdir / "job_inp.txt"
+        fileout_name = f"{self.fileout_prefix}.inp"
+        fnout = outdir / fileout_name
         with open(fnout, "w") as fp:
             fp.write(inputtext)
         with open(outdir / "fdmfile.txt", "w") as fp:
-            fp.write("1\njob_inp.txt")
+            fp.write(f"1\n{fileout_name}\n")
         logger.info(f"written `{fnout}`")
         return outdir
 
@@ -384,6 +388,8 @@ def struct2fdmnes(
     structs = get_structure_from_text(
         inp, absorber, frame=frame, format=format, filename=filename
     )
-    fout_name = f"{filename.replace('.', '_')}_{absorber.symbol}.inp"
-    fdm = FdmnesXasInput(structs, absorber=absorber)
-    return {"fdmfile.txt": f"1\n{fout_name}\n", fout_name: fdm.get_input()}
+    fout_name = f"{filename.replace('.', '_')}_{absorber.symbol}"
+    fdm = FdmnesXasInput(structs, absorber=absorber, fileout_prefix=fout_name)
+    return {"fdmfile.txt": f"1\n{fout_name}.inp\n", fout_name: fdm.get_input()}
+
+

--- a/larixite/fdmnes.py
+++ b/larixite/fdmnes.py
@@ -9,6 +9,7 @@ Generating FDMNES input files
 spectroscopy (XAS, XES, RIXS) from the atomic structures
 
 """
+
 from dataclasses import dataclass
 from typing import Union
 from pathlib import Path
@@ -340,12 +341,13 @@ class FdmnesXasInput:
         return outdir
 
 
-
-def struct2fdmnes(inp: Union[str, Path], absorber:
-                  Union[str, int, Element],
-                  frame: int = 0,
-                  format: str = 'cif',
-                  filename: Union[None, str] = None) -> dict:
+def struct2fdmnes(
+    inp: Union[str, Path],
+    absorber: Union[str, int, Element],
+    frame: int = 0,
+    format: str = "cif",
+    filename: Union[None, str] = None,
+) -> dict:
     """convert CIF/XYZ  into a dictionary of {name: text} for FDMNES output files
 
     Parameters
@@ -363,8 +365,8 @@ def struct2fdmnes(inp: Union[str, Path], absorber:
 
     Returns
     -------
-    XasStructure
-        The XAS structure group for the specified file and absorber.
+    dict
+        Dictionary with the FDMNES input
 
     """
     if len(inp) < 512 and Path(inp).exists():
@@ -372,16 +374,16 @@ def struct2fdmnes(inp: Union[str, Path], absorber:
             filename = Path(inp).absolute().as_posix()
         inp = read_textfile(inp)
     if filename is None:
-        filename = f'unknown.{format}'
+        filename = f"unknown.{format}"
 
     if isinstance(absorber, str):
         absorber = Element(absorber)
     elif isinstance(absorber, int):
         absorber = Element.from_Z(absorber)
 
-    structs = get_structure_from_text(inp, absorber, frame=frame, format=format,
-                                      filename=filename)
+    structs = get_structure_from_text(
+        inp, absorber, frame=frame, format=format, filename=filename
+    )
     fout_name = f"{filename.replace('.', '_')}_{absorber.symbol}.inp"
     fdm = FdmnesXasInput(structs, absorber=absorber)
-    return {'fdmfile.txt': f'1\n{fout_name}\n',
-            fout_name: fdm.get_input()}
+    return {"fdmfile.txt": f"1\n{fout_name}\n", fout_name: fdm.get_input()}

--- a/larixite/fdmnes.py
+++ b/larixite/fdmnes.py
@@ -215,8 +215,13 @@ class FdmnesXasInput:
             structout.append("Z_absorber")
             structout.append(f"   {self.absorber.Z}")
             #: space group
+            spgrp = self.xs.space_group
+            if spgrp == 1:  #: FDMNES doesn't recognize 1 as a space group -> `P1`
+                spgrp = "P1"
+            if spgrp == 2:  #: FDMNES doesn't recognize 2 as a space group -> `P-1`
+                spgrp = "P-1"
             structout.append("Spgroup")
-            structout.append(f"   {self.xs.space_group}")
+            structout.append(f"   {spgrp}")
             #: occupancy
             structout.append("Occupancy")
             #: crystal

--- a/larixite/struct/__init__.py
+++ b/larixite/struct/__init__.py
@@ -5,6 +5,7 @@
 Wrapper on top of pymatgen to handle atomic structures for XAS calculations
 ============================================================================
 """
+
 import tempfile
 import os
 from io import StringIO
@@ -86,7 +87,9 @@ def get_structure(
         try:
             struct = structs.parse_structures(primitive=False)[frame]
         except Exception:
-            raise ValueError(f"could not get structure {frame} from text of CIF {filepath}")
+            raise ValueError(
+                f"could not get structure {frame} from text of CIF {filepath}"
+            )
         molecule = Molecule.from_dict(struct.as_dict())
         logger.debug("structure created from a CIF file")
         structout = XasStructureCif(
@@ -96,10 +99,10 @@ def get_structure(
             structure=struct,
             molecule=molecule,
             struct_type="crystal",
-            absorber=Element(absorber)
+            absorber=Element(absorber),
         )
     #: XYZ
-    elif filepath.suffix == '.xyz':
+    elif filepath.suffix == ".xyz":
         xyz = XYZ.from_file(filepath)
         molecules = xyz.all_molecules
         molecule = molecules[frame]
@@ -112,7 +115,7 @@ def get_structure(
             structure=structure,
             molecule=molecule,
             struct_type="molecule",
-            absorber=Element(absorber)
+            absorber=Element(absorber),
         )
     else:
         raise ValueError(f"unknown structure format '{format}'")
@@ -124,11 +127,13 @@ def get_structure(
     return structout
 
 
-def get_structure_from_text(text: str,
-                            absorber: Union[str, int, Element],
-                            frame: int = 0,
-                            format: str = 'cif',
-                            filename: str = 'unknown.cif') -> XasStructure:
+def get_structure_from_text(
+    text: str,
+    absorber: Union[str, int, Element],
+    frame: int = 0,
+    format: str = "cif",
+    filename: str = "unknown.cif",
+) -> XasStructure:
     """Get an XasStructure from the text of a structural file, according to its format
 
     Parameters
@@ -164,20 +169,25 @@ def get_structure_from_text(text: str,
         try:
             struct = structs.parse_structures(primitive=False)[frame]
         except Exception:
-            raise ValueError(f"could not get structure {frame} from text of CIF {filename}")
+            raise ValueError(
+                f"could not get structure {frame} from text of CIF {filename}"
+            )
         molecule = Molecule.from_dict(struct.as_dict())
         logger.debug("structure created from a CIF file")
-        structout = XasStructureCif(name=filepath.name,  label=filepath.stem,
-                                    filepath=filepath,
-                                    structure=struct,
-                                    molecule=molecule,
-                                    struct_type="crystal",
-                                    absorber=absorber)
+        structout = XasStructureCif(
+            name=filepath.name,
+            label=filepath.stem,
+            filepath=filepath,
+            structure=struct,
+            molecule=molecule,
+            struct_type="crystal",
+            absorber=absorber,
+        )
 
     #: XYZ
-    elif format == 'xyz':
-        xyz_tfile = Path(tempfile.gettempdir(), 'tmp_0.xyz')
-        with open(xyz_tfile, 'w') as fh:
+    elif format == "xyz":
+        xyz_tfile = Path(tempfile.gettempdir(), "tmp_0.xyz")
+        with open(xyz_tfile, "w") as fh:
             fh.write(text)
 
         xyz = XYZ.from_file(xyz_tfile)
@@ -185,12 +195,15 @@ def get_structure_from_text(text: str,
         molecule = molecules[frame]
         structure = mol2struct(molecule)
         logger.debug("structure created from a XYZ file")
-        structout = XasStructureXyz(name=filepath.name, label=filepath.stem,
-                                    filepath=filepath,
-                                    structure=structure,
-                                    molecule=molecule,
-                                    struct_type="molecule",
-                                    absorber=absorber)
+        structout = XasStructureXyz(
+            name=filepath.name,
+            label=filepath.stem,
+            filepath=filepath,
+            structure=structure,
+            molecule=molecule,
+            struct_type="molecule",
+            absorber=absorber,
+        )
         os.unlink(xyz_tfile)
     else:
         raise ValueError(f"unknown structure format '{format}'")
@@ -200,6 +213,7 @@ def get_structure_from_text(text: str,
             f"[{structout.name}] contains partially occupied sites that are not fully supported yet"
         )
     return structout
+
 
 def get_structs_from_dir(
     structsdir: Union[str, Path],

--- a/larixite/templates/fdmnes_xas.tmpl
+++ b/larixite/templates/fdmnes_xas.tmpl
@@ -7,15 +7,15 @@ Python
 Comment
 {comment}
 Filout
-   job
+{filout}
 Edge
-   {edge}
+{edge}
 !<Energy range>
 Range
-   {erange}
+{erange}
 {Energpho}
 Radius
-   {radius}
+{radius}
 !<Multipolar expansion>
 {Quadrupole}
 {TDDFT}

--- a/larixite/utils.py
+++ b/larixite/utils.py
@@ -141,26 +141,26 @@ def show_loggers(clear_handlers=False):
             print(f"+-> Level: {handler.level} ({logging.getLevelName(handler.level)})")
 
 
-
-
 def bytes2str(bytedata):
     "decode bytes using charset_normalizer.from_bytes"
     return str(from_bytes(bytedata).best())
 
+
 def get_path(val: Union[Path, str, bytes]):
-    """return best guess for a posix-style path name from an input string
-    """
+    """return best guess for a posix-style path name from an input string"""
     if isinstance(val, bytes):
         val = bytes2str(val)
     if isinstance(val, str):
         val = Path(val)
     return val.absolute()
 
+
 def is_gzip(filename):
     "is a file gzipped?"
-    with open(get_path(filename), 'rb') as fh:
-        return fh.read(3) == b'\x1f\x8b\x08'
+    with open(get_path(filename), "rb") as fh:
+        return fh.read(3) == b"\x1f\x8b\x08"
     return False
+
 
 def read_textfile(filename: Union[Path, io.IOBase, str, bytes], size=None) -> str:
     """read text from a file as string (decoding from bytes)
@@ -182,15 +182,14 @@ def read_textfile(filename: Union[Path, io.IOBase, str, bytes], size=None) -> st
        splitting on '\n' will give a list of lines.
     3. if filename is given, it can be a gzip-compressed file
     """
-    text = ''
-
+    text = ""
 
     if isinstance(filename, io.IOBase):
         text = filename.read(size)
-        if filename.mode == 'rb':
+        if filename.mode == "rb":
             text = bytes2str(text)
     else:
         fopen = GzipFile if is_gzip(filename) else open
-        with fopen(get_path(filename), 'rb') as fh:
+        with fopen(get_path(filename), "rb") as fh:
             text = bytes2str(fh.read(size))
-    return text.replace('\r\n', '\n').replace('\r', '\n')
+    return text.replace("\r\n", "\n").replace("\r", "\n")

--- a/larixite/utils.py
+++ b/larixite/utils.py
@@ -18,18 +18,6 @@ try:
 except ImportError:
     getpwnam = None
 
-HAS_IPYTHON = False
-try:
-    from IPython.core.interactiveshell import InteractiveShell
-
-    HAS_IPYTHON = True
-except ImportError:
-    pass
-
-# Enable color output in Jupyter Notebook
-if HAS_IPYTHON:
-    InteractiveShell.ast_node_interactivity = "all"
-
 
 def get_homedir() -> Path:
     """

--- a/larixite/webapp/webapp.py
+++ b/larixite/webapp/webapp.py
@@ -206,17 +206,18 @@ def cifs(cifid=None):
             with_h = request.form.get('with_h') in ('1', 'on', 'True', 1, True)
             config['with_h'] = with_h = int(with_h)
             if config['ciftext'] is not None:
-                out = struct2fdmnes(config['ciftext'], absorber=absorber,
-                                        filename=f'AMSCD_{cifid}.cif')
                 cifid = config['cifid']
                 if config['ciffile'] not in ('', None, 'None'):
-                    cifid = config['ciffile']
+                    cifid = ciffile = config['ciffile']
                 elif config['cifid'] is not None:
                     cifid = config['cifid']
+                    ciffile = f'AMSCD_{cifid}.cif'
                     config['cif_link'] = (f'AMSCD_{cifid}.cif', cifid)
                     config['zip_link'] = (f'AMSCD_{cifid}_fdmnes.zip', cifid,
                                          absorber, edge, cluster_size, with_h, 'fdmnes')
                 config['out_links'] = {}
+                out = struct2fdmnes(config['ciftext'], absorber=absorber,
+                                        filename=ciffile)
                 for slabel, text in out.items():
                     link = f'fdmnes_{slabel}'
                     config['out_links'][slabel] = (slabel, cifid, absorber, edge, 0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "xraydb",
     "sqlalchemy>=2",
     "pymatgen>=2024.10.22",
-    "pyshortcuts",
 ]
 
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ authors = [
 dependencies = [
     "xraydb",
     "sqlalchemy>=2",
-    "pymatgen>=2024.10.22",
+    "pymatgen>=2025.6.14",
+    "mp-api>=0.45.8",
+    "emmet-core>=0.84.9",
 ]
 
 license = "MIT"
@@ -46,7 +48,7 @@ Tracker = "https://github.com/xraypy/larixite/issues"
 
 [project.optional-dependencies]
 web = ["flask"]
-jupyter = ["jupyterlab==3.*", "crystal-toolkit>=2025.1.24rc0"]
+jupyter = ["jupyterlab==3.*", "crystal-toolkit>=2025.7.31"]
 test = ["pytest"]
 doc = ["sphinx"]
 dev = ["build", "twine", "ruff"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ Tracker = "https://github.com/xraypy/larixite/issues"
 
 [project.optional-dependencies]
 web = ["flask"]
-jupyter = ["jupyterlab==3.*", "crystal-toolkit==2025.1.24rc0"]
+jupyter = ["jupyterlab==3.*", "crystal-toolkit>=2025.1.24rc0"]
 test = ["pytest"]
 doc = ["sphinx"]
 dev = ["build", "twine", "ruff"]


### PR DESCRIPTION
@newville I have done a couple of fixes and, most importantly, removed the IPython InteractiveShell call from the logging module, that may make Larch fail (see my latest pull request then).

For the moment I have removed the `pyshortcuts` dependency as we have copied only a couple of simple functions. We may reintroduce it later on if we use it more.

For the web application, there is bug in the names of the generated FDMNES files. The `.inp` extension is missing (I have modified it in the `write_input` method, but the web app is not using such method). Furtermore the `AMSCD_` prefix to the filename is always added, even for uploaded CIF files. Is not clear to me how to fix this. If you have the possibility to have a look, it would be great, otherwise we can leave like this as the fix is straighforward after downloading the files to run FDMNES.

NOTE: it is important to release `larixite 2025.5.1` before releasing `larch 2025.3.0`